### PR TITLE
feat(a11y): add reduced-motion support and a skip link

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -36,6 +36,10 @@ describe('App', () => {
     expect(
       screen.getByRole('button', { name: 'インポート' }),
     ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: 'メインコンテンツへスキップ' }),
+    ).toHaveAttribute('href', '#main-content');
+    expect(document.querySelector('main#main-content')).not.toBeNull();
   });
 
   it('主要ページの見出しを日本語で表示する', () => {

--- a/src/components/common/Button.test.tsx
+++ b/src/components/common/Button.test.tsx
@@ -11,6 +11,14 @@ describe('Button', () => {
     expect(button.className).toContain('transition-transform');
   });
 
+  it('reduced motion 向けのクラスが適用されている', () => {
+    render(<Button>テスト</Button>);
+    const button = screen.getByRole('button', { name: 'テスト' });
+    expect(button.className).toContain('motion-reduce:transition-none');
+    expect(button.className).toContain('motion-reduce:transform-none');
+    expect(button.className).toContain('motion-reduce:active:scale-100');
+  });
+
   it('フォーカスリングのクラスが適用されている', () => {
     render(<Button>テスト</Button>);
     const button = screen.getByRole('button', { name: 'テスト' });

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -7,7 +7,7 @@ export default function Button({ children, className = '', ...props }: ButtonPro
     <button
       className={[
         'inline-flex items-center justify-center rounded-full px-4 py-2 font-medium',
-        'bg-slate-900 text-white transition-transform hover:bg-slate-700 active:scale-[0.97] disabled:cursor-not-allowed disabled:bg-slate-300 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300 dark:disabled:bg-slate-700 dark:disabled:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2',
+        'bg-slate-900 text-white transition-transform motion-reduce:transform-none motion-reduce:transition-none hover:bg-slate-700 active:scale-[0.97] motion-reduce:active:scale-100 disabled:cursor-not-allowed disabled:bg-slate-300 dark:bg-slate-100 dark:text-slate-900 dark:hover:bg-slate-300 dark:disabled:bg-slate-700 dark:disabled:text-slate-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2',
         className,
       ].join(' ')}
       {...props}

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -15,8 +15,14 @@ export default function Layout() {
   useTheme();
   return (
     <div className="min-h-screen">
+      <a
+        href="#main-content"
+        className="sr-only absolute left-4 top-4 rounded-full bg-sky-600 px-4 py-2 font-medium text-white focus:not-sr-only focus:z-50 focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2"
+      >
+        メインコンテンツへスキップ
+      </a>
       <Header />
-      <main className="mx-auto max-w-6xl px-6 py-10">
+      <main id="main-content" className="mx-auto max-w-6xl px-6 py-10">
         <Outlet />
       </main>
     </div>

--- a/src/components/quiz/QuizProgress.test.tsx
+++ b/src/components/quiz/QuizProgress.test.tsx
@@ -60,6 +60,7 @@ describe('QuizProgress', () => {
       const streakElement = screen.getByText('3連続正解');
       expect(streakElement.className).toContain('text-amber-500');
       expect(streakElement.className).toContain('animate-bounce-subtle');
+      expect(streakElement.className).toContain('motion-reduce:animate-none');
     });
 
     it('streak 5-6 で orange 色とバウンスアニメーション、テキスト拡大が適用される', () => {
@@ -67,6 +68,7 @@ describe('QuizProgress', () => {
       const streakElement = screen.getByText('5連続正解');
       expect(streakElement.className).toContain('text-orange-500');
       expect(streakElement.className).toContain('animate-bounce-medium');
+      expect(streakElement.className).toContain('motion-reduce:animate-none');
       expect(streakElement.className).toContain('text-base');
     });
 
@@ -75,6 +77,7 @@ describe('QuizProgress', () => {
       const streakElement = screen.getByText('7連続正解');
       expect(streakElement.className).toContain('text-red-500');
       expect(streakElement.className).toContain('animate-bounce-strong');
+      expect(streakElement.className).toContain('motion-reduce:animate-none');
       expect(streakElement.className).toContain('text-lg');
     });
 

--- a/src/components/quiz/QuizProgress.tsx
+++ b/src/components/quiz/QuizProgress.tsx
@@ -6,12 +6,12 @@ type Props = {
 
 function getStreakStyle(streak: number) {
   if (streak >= 7) {
-    return 'text-lg font-bold text-red-500 animate-bounce-strong';
+    return 'text-lg font-bold text-red-500 animate-bounce-strong motion-reduce:animate-none';
   }
   if (streak >= 5) {
-    return 'text-base font-bold text-orange-500 animate-bounce-medium';
+    return 'text-base font-bold text-orange-500 animate-bounce-medium motion-reduce:animate-none';
   }
-  return 'text-sm font-medium text-amber-500 animate-bounce-subtle';
+  return 'text-sm font-medium text-amber-500 animate-bounce-subtle motion-reduce:animate-none';
 }
 
 export default function QuizProgress({ current, total, streak }: Props) {


### PR DESCRIPTION
## Summary
- add a keyboard-accessible skip link before the header and target the main content region
- honor `prefers-reduced-motion` for streak animations and the shared button press animation
- add test coverage for the new accessibility classes and skip-link markup

## Testing
- `npm test`
- `npm run build` *(currently fails on pre-existing TypeScript issues in unrelated test files on main; no failures came from the files changed in this PR)*

Closes #30